### PR TITLE
Refactor sales date handling to use created_at timestamp

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -289,7 +289,7 @@ class DashboardController extends Controller
     {
         $query = Sale::with(['branch', 'client', 'seller'])
             ->where('status', 'completed')
-            ->orderBy('date', 'desc')
+            ->orderBy('created_at', 'desc')
             ->limit($limit);
 
         if ($branchId) {

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -61,7 +61,7 @@ class SaleController extends Controller
             $query->whereDate('date', '<=', $request->date_to);
         }
 
-        $sales = $query->orderBy('date', 'desc')
+        $sales = $query->orderBy('created_at', 'desc')
             ->paginate(10)
             ->withQueryString();
 

--- a/resources/js/pages/sales/index.tsx
+++ b/resources/js/pages/sales/index.tsx
@@ -461,9 +461,7 @@ export default function Index({ sales, filters }: PageProps) {
                             <div className="p-4 text-center text-muted-foreground">No se encontraron ventas con los filtros seleccionados</div>
                         ) : (
                             <div className="flex flex-col gap-4 p-2">
-                                {[...sales.data]
-                                    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-                                    .map((sale) => (
+                                {sales.data.map((sale) => (
                                         <div key={sale.id} className="rounded-lg border bg-card p-4 shadow-sm">
                                             <div className="mb-2 flex items-center justify-between">
                                                 <div className="text-base font-semibold">{sale.code}</div>


### PR DESCRIPTION
- Updated DashboardController and SaleController to order sales by 'created_at' instead of 'date' for consistency in data retrieval.
- Adjusted frontend sales display logic to directly map sales data without additional sorting, improving performance.